### PR TITLE
Revert "update Dockerfiles for ruby2.3 to use ruby 2.3.8"

### DIFF
--- a/2.3/ubuntu14.04/Dockerfile
+++ b/2.3/ubuntu14.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.3
-ENV RUBY_VERSION 2.3.8
-ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+ENV RUBY_VERSION 2.3.7
+ENV RUBY_DOWNLOAD_SHA256 c61f8f2b9d3ffff5567e186421fa191f0d5e7c2b189b426bb84498825d548edb
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby

--- a/2.3/ubuntu16.04/Dockerfile
+++ b/2.3/ubuntu16.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.3
-ENV RUBY_VERSION 2.3.8
-ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+ENV RUBY_VERSION 2.3.7
+ENV RUBY_DOWNLOAD_SHA256 c61f8f2b9d3ffff5567e186421fa191f0d5e7c2b189b426bb84498825d548edb
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby

--- a/2.3/ubuntu18.04/Dockerfile
+++ b/2.3/ubuntu18.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.3
-ENV RUBY_VERSION 2.3.8
-ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+ENV RUBY_VERSION 2.3.7
+ENV RUBY_DOWNLOAD_SHA256 c61f8f2b9d3ffff5567e186421fa191f0d5e7c2b189b426bb84498825d548edb
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby


### PR DESCRIPTION
Reverts Gusto/ruby#4

This pr set the ruby version for this docker image to be 2.3.8. This broke DZ deploys because DZ uses 2.3.7