### PR TITLE
Pin ubuntu images to a sha

### DIFF
--- a/2.3/ubuntu14.04/Dockerfile
+++ b/2.3/ubuntu14.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.3/ubuntu16.04/Dockerfile
+++ b/2.3/ubuntu16.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:6239ca16d54d8edd38788aacde7c6426e5999ffbbd7e97ac3cf04d474341d079
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.3/ubuntu18.04/Dockerfile
+++ b/2.3/ubuntu18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:b88f8848e9a1a4e4558ba7cfc4acc5879e1d0e7ac06401409062ad2627e6fb58
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/ubuntu14.04/Dockerfile
+++ b/2.4/ubuntu14.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/ubuntu16.04/Dockerfile
+++ b/2.4/ubuntu16.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:6239ca16d54d8edd38788aacde7c6426e5999ffbbd7e97ac3cf04d474341d079
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/ubuntu18.04/Dockerfile
+++ b/2.4/ubuntu18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:b88f8848e9a1a4e4558ba7cfc4acc5879e1d0e7ac06401409062ad2627e6fb58
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.5/ubuntu14.04/Dockerfile
+++ b/2.5/ubuntu14.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.5/ubuntu16.04/Dockerfile
+++ b/2.5/ubuntu16.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:6239ca16d54d8edd38788aacde7c6426e5999ffbbd7e97ac3cf04d474341d079
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.5/ubuntu18.04/Dockerfile
+++ b/2.5/ubuntu18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:b88f8848e9a1a4e4558ba7cfc4acc5879e1d0e7ac06401409062ad2627e6fb58
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.6/ubuntu14.04/Dockerfile
+++ b/2.6/ubuntu14.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.6/ubuntu16.04/Dockerfile
+++ b/2.6/ubuntu16.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:6239ca16d54d8edd38788aacde7c6426e5999ffbbd7e97ac3cf04d474341d079
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.6/ubuntu18.04/Dockerfile
+++ b/2.6/ubuntu18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:b88f8848e9a1a4e4558ba7cfc4acc5879e1d0e7ac06401409062ad2627e6fb58
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## What does this do?  
Makes our builds more reproducible.  While we do want to pull in the latest ubuntu images, we want to know/have some control over when that happens so that we can revert if something breaks.

## How does it work?  

Docker supports adding a SHA to avoid this problem, documented [here](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier). Note the if both the tag and the sha are specified but are inconsistent, the sha "wins" and that container is pulled.

To update to a new version, run a docker pull of the desired tag and write the SHA that is returned alongside the new tag in the docker file.  This is a bit annoying and we should [automate this soon](https://jira.gustocorp.com/browse/DEVOPS-4032).  

## How was it tested?
Ran local docker builds

## Here's the Jira link  
https://jira.gustocorp.com/browse/DEVOPS-3965

## Here's a fun image for your troubles  
![image](https://user-images.githubusercontent.com/5797695/66008445-431b3180-e46b-11e9-8881-c86ce79ff5a4.png)
