### PR TITLE
Ruby upgrades

### DIFF
--- a/2.4/ubuntu14.04/Dockerfile
+++ b/2.4/ubuntu14.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.4
-ENV RUBY_VERSION 2.4.4
-ENV RUBY_DOWNLOAD_SHA256 1d0034071d675193ca769f64c91827e5f54cb3a7962316a41d5217c7bc6949f0
+ENV RUBY_VERSION 2.4.7
+ENV RUBY_DOWNLOAD_SHA256 a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby
@@ -35,6 +35,7 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
+		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.4/ubuntu14.04/Dockerfile
+++ b/2.4/ubuntu14.04/Dockerfile
@@ -35,7 +35,6 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
-		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.4/ubuntu16.04/Dockerfile
+++ b/2.4/ubuntu16.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.4
-ENV RUBY_VERSION 2.4.4
-ENV RUBY_DOWNLOAD_SHA256 1d0034071d675193ca769f64c91827e5f54cb3a7962316a41d5217c7bc6949f0
+ENV RUBY_VERSION 2.4.7
+ENV RUBY_DOWNLOAD_SHA256 a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby
@@ -35,6 +35,7 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
+ 		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.4/ubuntu16.04/Dockerfile
+++ b/2.4/ubuntu16.04/Dockerfile
@@ -35,7 +35,6 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
- 		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.4/ubuntu18.04/Dockerfile
+++ b/2.4/ubuntu18.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.4
-ENV RUBY_VERSION 2.4.4
-ENV RUBY_DOWNLOAD_SHA256 1d0034071d675193ca769f64c91827e5f54cb3a7962316a41d5217c7bc6949f0
+ENV RUBY_VERSION 2.4.7
+ENV RUBY_DOWNLOAD_SHA256 a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby
@@ -35,6 +35,7 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
+		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.4/ubuntu18.04/Dockerfile
+++ b/2.4/ubuntu18.04/Dockerfile
@@ -35,7 +35,6 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libbz2-dev \
-		libgdbm-compat-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
 		libncurses-dev \

--- a/2.5/ubuntu14.04/Dockerfile
+++ b/2.5/ubuntu14.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.5
-ENV RUBY_VERSION 2.5.1
-ENV RUBY_DOWNLOAD_SHA256 886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d
+ENV RUBY_VERSION 2.5.6
+ENV RUBY_DOWNLOAD_SHA256 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby

--- a/2.5/ubuntu16.04/Dockerfile
+++ b/2.5/ubuntu16.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.5
-ENV RUBY_VERSION 2.5.1
-ENV RUBY_DOWNLOAD_SHA256 886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d
+ENV RUBY_VERSION 2.5.6
+ENV RUBY_DOWNLOAD_SHA256 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby

--- a/2.5/ubuntu18.04/Dockerfile
+++ b/2.5/ubuntu18.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.5
-ENV RUBY_VERSION 2.5.1
-ENV RUBY_DOWNLOAD_SHA256 886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d
+ENV RUBY_VERSION 2.5.6
+ENV RUBY_DOWNLOAD_SHA256 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
 ENV RUBYGEMS_VERSION 3.0.1
 
 # some of ruby's build scripts are written in ruby

--- a/2.6/ubuntu14.04/Dockerfile
+++ b/2.6/ubuntu14.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.0
-ENV RUBY_DOWNLOAD_SHA256 acb00f04374899ba8ee74bbbcb9b35c5c6b1fd229f1876554ee76f0f1710ff5f
+ENV RUBY_VERSION 2.6.4
+ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6/ubuntu16.04/Dockerfile
+++ b/2.6/ubuntu16.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.0
-ENV RUBY_DOWNLOAD_SHA256 acb00f04374899ba8ee74bbbcb9b35c5c6b1fd229f1876554ee76f0f1710ff5f
+ENV RUBY_VERSION 2.6.4
+ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6/ubuntu18.04/Dockerfile
+++ b/2.6/ubuntu18.04/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.0
-ENV RUBY_DOWNLOAD_SHA256 acb00f04374899ba8ee74bbbcb9b35c5c6b1fd229f1876554ee76f0f1710ff5f
+ENV RUBY_VERSION 2.6.4
+ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built


### PR DESCRIPTION
## What does this do?  
Bumps the minor versions of our various ruby major versions

## How does it work?  
I reviewed a [recent diff](https://github.com/docker-library/ruby/compare/9ae0943fa2935b3a13c72ae7d6afa2439145d7fa...6a7df7a72b4a3d1b3e06ead303841b3fdaca560e) and copied the versions over.  That diff looks very busy because somebody decided they preferred `;` to `&&`.  

One other difference was the addition of libgdm-compat-dev.  Ubuntu repos don't have this package so I left that one off.  Also the 2.7 version of ruby was added but it's still an RC so I'm going to wait till that is GA


## How was it tested?
Did a docker build for one of the ubuntu flavors for each ruby version

## Here's the Jira link  
https://jira.gustocorp.com/browse/DEVOPS-3965

## Here's a fun image for your troubles  
![image](https://thumbs.gfycat.com/BruisedAromaticGalapagospenguin-size_restricted.gif)