### PR TITLE
Remove tags because they can be found in the tags section

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,18 +1,3 @@
-# Supported tags and respective `Dockerfile` links
-
--	[`2.6-ubuntu18.04`, `2.6`, `2` (*2.6/ubuntu18.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.6/ubuntu18.04/Dockerfile)
--	[`2.6-ubuntu16.04` (*2.6/ubuntu16.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.6/ubuntu16.04/Dockerfile)
--	[`2.6-ubuntu14.04` (*2.6/ubuntu14.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.6/ubuntu14.04/Dockerfile)
--	[`2.5-ubuntu18.04`, `2.5` (*2.5/ubuntu18.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.5/ubuntu18.04/Dockerfile)
--	[`2.5-ubuntu16.04` (*2.5/ubuntu16.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.5/ubuntu16.04/Dockerfile)
--	[`2.5-ubuntu14.04` (*2.5/ubuntu14.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.5/ubuntu14.04/Dockerfile)
--	[`2.4-ubuntu18.04`, `2.4` (*2.4/ubuntu18.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.4/ubuntu18.04/Dockerfile)
--	[`2.4-ubuntu16.04` (*2.4/ubuntu16.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.4/ubuntu16.04/Dockerfile)
--	[`2.4-ubuntu14.04` (*2.4/ubuntu14.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.4/ubuntu14.04/Dockerfile)
--	[`2.3-ubuntu18.04`, `2.3` (*2.3/ubuntu18.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.3/ubuntu18.04/Dockerfile)
--	[`2.3-ubuntu16.04` (*2.3/ubuntu16.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.3/ubuntu16.04/Dockerfile)
--	[`2.3-ubuntu14.04` (*2.3/ubuntu14.04/Dockerfile*)](https://github.com/Gusto/ruby/blob/master/2.3/ubuntu14.04/Dockerfile)
-
 # Quick reference
 
 -	**Where to file issues**:  


### PR DESCRIPTION
Outdated and it will always be outdated unless we keep it maintained. Since you can browse tabs on Dockerhub, I think this can be removed. 

In the screenshot, I think having the tags show up is a little confusing when they can be found in the `Tags` tab. 

<img width="1286" alt="Screen Shot 2021-05-03 at 3 57 37 PM" src="https://user-images.githubusercontent.com/1251946/116926426-559db400-ac28-11eb-9b67-48a98d59c534.png">
