### PR TITLE
Add Ruby 2.7 on Ubuntu 20.04

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,10 @@
 ---
-- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu18.04"
-  command: docker build -f ./3.0/ubuntu18.04/Dockerfile .
-- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu16.04"
-  command: docker build -f ./3.0/ubuntu16.04/Dockerfile .
-- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu14.04"
-  command: docker build -f ./3.0/ubuntu14.04/Dockerfile .
 - name: ":ruby:Ruby 2.7 on :ubuntu:ubuntu18.04"
   command: docker build -f ./2.7/ubuntu18.04/Dockerfile .
 - name: ":ruby:Ruby 2.7 on :ubuntu:ubuntu16.04"
   command: docker build -f ./2.7/ubuntu16.04/Dockerfile .
+- name: ":ruby:Ruby 2.7 on :ubuntu:ubuntu20.04"
+  command: docker build -f ./2.7/ubuntu20.04/Dockerfile .
 - name: ":ruby:Ruby 2.7 on :ubuntu:ubuntu14.04"
   command: docker build -f ./2.7/ubuntu14.04/Dockerfile .
 - name: ":ruby:Ruby 2.6 on :ubuntu:ubuntu18.04"
@@ -17,6 +13,12 @@
   command: docker build -f ./2.6/ubuntu16.04/Dockerfile .
 - name: ":ruby:Ruby 2.6 on :ubuntu:ubuntu14.04"
   command: docker build -f ./2.6/ubuntu14.04/Dockerfile .
+- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu18.04"
+  command: docker build -f ./3.0/ubuntu18.04/Dockerfile .
+- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu16.04"
+  command: docker build -f ./3.0/ubuntu16.04/Dockerfile .
+- name: ":ruby:Ruby 3.0 on :ubuntu:ubuntu14.04"
+  command: docker build -f ./3.0/ubuntu14.04/Dockerfile .
 - name: ":ruby:Ruby 2.4 on :ubuntu:ubuntu18.04"
   command: docker build -f ./2.4/ubuntu18.04/Dockerfile .
 - name: ":ruby:Ruby 2.4 on :ubuntu:ubuntu16.04"

--- a/2.7/ubuntu20.04/Dockerfile
+++ b/2.7/ubuntu20.04/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
 	\
-	&& rm -r /root/.gem/ \
 # rough smoke test
 	&& ruby --version \
 	&& gem --version \

--- a/2.7/ubuntu20.04/Dockerfile
+++ b/2.7/ubuntu20.04/Dockerfile
@@ -1,0 +1,97 @@
+FROM ubuntu:20.04 as builder
+
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.3
+ENV RUBY_DOWNLOAD_SHA256 5e91d1650857d43cd6852e05ac54683351e9c301811ee0bef43a67c4605e7db1
+ENV LANG C.UTF-8
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm6 \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+		tzdata \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		autoconf \
+		bison \
+		dpkg-dev \
+		gcc \
+		libbz2-dev \
+		libgdbm-dev \
+		libglib2.0-dev \
+		libncurses-dev \
+		libreadline-dev \
+		libxml2-dev \
+		libxslt-dev \
+		make \
+		ruby \
+		wget \
+		xz-utils \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+# rough smoke test
+	&& ruby --version && gem --version && bundle --version
+
+# don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $GEM_HOME/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+
+CMD [ "irb" ]

--- a/2.7/ubuntu20.04/Dockerfile
+++ b/2.7/ubuntu20.04/Dockerfile
@@ -1,21 +1,16 @@
-FROM ubuntu:20.04 as builder
-
-ENV RUBY_MAJOR 2.7
-ENV RUBY_VERSION 2.7.3
-ENV RUBY_DOWNLOAD_SHA256 5e91d1650857d43cd6852e05ac54683351e9c301811ee0bef43a67c4605e7db1
-ENV LANG C.UTF-8
+FROM ubuntu:20.04
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgdbm6 \
-		libssl-dev \
-		libyaml-dev \
-		procps \
+		build-essential \
+		bison \
 		zlib1g-dev \
-		tzdata \
+		libyaml-dev \
+		libssl-dev \
+		libgdbm-dev \
+		libreadline-dev \
+		libffi-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation
@@ -25,26 +20,32 @@ RUN mkdir -p /usr/local/etc \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.3
+ENV RUBY_DOWNLOAD_SHA256 5e91d1650857d43cd6852e05ac54683351e9c301811ee0bef43a67c4605e7db1
+
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -ex \
 	\
 	&& buildDeps=' \
+		apt-utils \
 		autoconf \
+		automake \
 		bison \
-		dpkg-dev \
-		gcc \
-		libbz2-dev \
+		libc6-dev \
+		libffi-dev \
 		libgdbm-dev \
-		libglib2.0-dev \
-		libncurses-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
 		libreadline-dev \
-		libxml2-dev \
-		libxslt-dev \
+		libsqlite3-dev \
 		make \
-		ruby \
+		patch \
+		pkg-config \
+		sqlite3 \
 		wget \
-		xz-utils \
 	' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $buildDeps \
@@ -83,14 +84,20 @@ RUN set -ex \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
+	\
+	&& rm -r /root/.gem/ \
 # rough smoke test
-	&& ruby --version && gem --version && bundle --version
+	&& ruby --version \
+	&& gem --version \
+	&& bundle --version
 
 # don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $GEM_HOME/bin:$PATH
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 


### PR DESCRIPTION
This version no longer sets BUNDLE_PATH as per https://github.com/docker-library/ruby/issues/297